### PR TITLE
Support password-protected projects and self-hosted ShareLaTeX sites

### DIFF
--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -211,7 +211,7 @@ def fetch_updates(url, email, password):
                 password = getpass.getpass("Enter password: ")
             Logger().log("Logging in {} with user {}...".format(login_url, email))
             r = s.get(login_url)
-            csrf = BeautifulSoup(r.text).find('input', { 'name' : '_csrf' })['value']
+            csrf = BeautifulSoup(r.text, 'html.parser').find('input', { 'name' : '_csrf' })['value']
             s.post(login_url, { '_csrf' : csrf , 'email' : email , 'password' : password })
 
         r = s.get(download_url, stream=True)
@@ -235,7 +235,7 @@ def fetch_updates(url, email, password):
 
     try:
         r = s.get(url)
-        return BeautifulSoup(r.text).find('title').text.rsplit('-',1)[0].strip()
+        return BeautifulSoup(r.text, 'html.parser').find('title').text.rsplit('-',1)[0].strip()
     except:
         return None
 #------------------------------------------------------------------------------

--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -234,8 +234,8 @@ def fetch_updates(url, email, password):
     os.remove(file_name)
 
     try:
-        u = urllib.request.urlopen(url)
-        return re.compile("<title.*?>(.+?) - ShareLaTeX, Online LaTeX Editor</title>", re.I).findall(u.read().decode())[0]
+        r = s.get(url)
+        return BeautifulSoup(r.text).find('title').text.rsplit('-',1)[0].strip()
     except:
         return None
 #------------------------------------------------------------------------------

--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -284,7 +284,7 @@ def determine_config_value(key, value):
             while True:
                 print(
                     'Conflicting {key_name}. Given {old}, but previous records show {new}. Which to use?\n1. {old} [old]\n2. {new} [new]'.format(
-                        key_name=key, old=saved_url, new=url))
+                        key_name=key, old=saved_value, new=value))
                 ans = input('Id to use [blank = 2.] -> ')
                 if ans.strip() == '':
                     ans = '2'


### PR DESCRIPTION
This PR includes the following changes:

* As the initial version, the argument can be either a project id or a full URL. When users provide a project ID, the program works as before (i.e., it is assumed that the project is hosted on https://www.sharelatex.com). When users provide a URL, the URL can point to any ShareLaTeX installation. Thus, not only projects on www.sharelatex.com are supported, but also self-hosted servers are supported.

* Private projects are supported. Credentials can be provided using two additional arguments: [-e|--email] and [--password]. The password may be omitted. In such a case, the user will be always prompted for it. The password is NEVER stored on disk.

* Format of .sharelatex-git files has changed to support any arbitrary set of configuration values (no backwards compatibility has been added to support the old format). Currently, url and email is being saved. Conflict handling procedure is maintained.

* Deprecated code in "fetch_updates" has been removed.