### PR TITLE
Add only unzipped files to commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sharelatex_git',
-    version='0.1',
+    version='0.2',
     scripts=['sharelatex-git'],
     install_requires=[
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name='sharelatex_git',
+    version='0.1',
+    scripts=['sharelatex-git'],
+    install_requires=[
+        'requests',
+        'bs4',
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='sharelatex_git',
-    version='0.2',
+    version='0.3',
     scripts=['sharelatex-git'],
     install_requires=[
         'requests',

--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -1,5 +1,5 @@
-# -*- coding: utf-8 -*-
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 ##
 ## Copyright (C) 2015-2017 João Ricardo Lourenço <jorl17.8@gmail.com>
 ## Copyright (C) 2017 Abel Gómez (https://github.com/abelgomez)

--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -237,10 +237,10 @@ def fetch_updates(url, email, password):
     
     try:
         with ZipFile(file_name, 'r') as f:
+            f.extractall()
             for zipfile_info in f.infolist():
                 commit_add_file(zipfile_info.filename)
                 Logger().log("Adding file {}".format(zipfile_info.filename))
-            f.extractall()
     except BadZipFile:
         os.remove(file_name)
         Logger().fatal_error("Downloaded file is not a zip file. Make sure that your project is public or you have provided a valid e-mail and password?")

--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -168,14 +168,18 @@ def ensure_git_repository_started():
         init_git_repository()
 
 #------------------------------------------------------------------------------
-# Commit all changes. Note that we do this with '.' at the end of the command,
-# so as to only commit changes in our directory. We also commit any possible
-# changes to the gitignore file. The commit message is optional and it is
-# always preceeded by a timestamp and the sharelatex-git-integration identifier
-# The project title, if not null, is also always appended to the message.
+# Add the file to the staged area for commit
+#------------------------------------------------------------------------------
+def commit_add_file(filename):
+    run_cmd('git add {}'.format(filename))
+
+#------------------------------------------------------------------------------
+# We also commit any possible changes to the gitignore file. The commit message
+# is optional and it is always preceeded by a timestamp and the
+# sharelatex-git-integration identifier The project title, if not null, is
+# also always appended to the message.
 #------------------------------------------------------------------------------
 def commit_all_changes(message, title):
-    run_cmd('git add -A .')
     run_cmd('git add -A {}'.format(get_git_ignore()))
     if title:
         cmd = 'git commit -m"[sharelatex-git-integration {} {}]'.format(title, get_timestamp())
@@ -233,6 +237,9 @@ def fetch_updates(url, email, password):
     
     try:
         with ZipFile(file_name, 'r') as f:
+            for zipfile_info in f.infolist():
+                commit_add_file(zipfile_info.filename)
+                Logger().log("Adding file {}".format(zipfile_info.filename))
             f.extractall()
     except BadZipFile:
         os.remove(file_name)


### PR DESCRIPTION
Using `git add -A` caused to add unwanted files (that were in the tree, and should be) to the git project.