### PR TITLE
files_changed() should now look for "working tree clean"

### DIFF
--- a/sharelatex-git
+++ b/sharelatex-git
@@ -1,1 +1,1 @@
-sharelatex-git.py
+sharelatex_git.py

--- a/sharelatex-git.py
+++ b/sharelatex-git.py
@@ -196,7 +196,9 @@ def commit_all_changes(message, title):
 #------------------------------------------------------------------------------
 def files_changed():
     out = run_cmd('git status .').decode('utf-8')
-    return 'nothing to commit, working directory clean' not in out.lower()
+    return ('nothing to commit, working directory clean' not in out.lower()
+            and
+            'nothing to commit, working tree clean' not in out.lower())
 
 #------------------------------------------------------------------------------
 # Download the sharelatex project and extract it. Die out if there's any

--- a/sharelatex_git.py
+++ b/sharelatex_git.py
@@ -146,7 +146,7 @@ def ensure_gitignore_is_fine():
                 if s not in lines:
                     f.write(s + '\n')
 
-            write_if_not_there('sharelatex-git.py')
+            write_if_not_there('sharelatex_git.py')
             write_if_not_there('sharelatex-git')
             write_if_not_there('.sharelatex-git')
     except:
@@ -437,4 +437,5 @@ def parse_input():
 #------------------------------------------------------------------------------
 # Go, go, go!
 #------------------------------------------------------------------------------
-go(*parse_input())
+if __name__ == '__main__':
+    go(*parse_input())


### PR DESCRIPTION
As of git version 2.9.1, nothing to commit message now says "working tree clean", not "working directory clean". Checking for either, to retain compatibility pre-2.9.1.

https://raw.githubusercontent.com/git/git/master/Documentation/RelNotes/2.9.1.txt